### PR TITLE
Add frontend language cookie functionality

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,5 +2,5 @@ Wegmeister:
   LanguageRedirect:
     # Add mappings for language codes if you use some different codes than the default ones.
     languageCodeOverrides: {}
-    # configure the name of your frontend language cookie name
-    feLanguageCookieName: _fe_language
+    # Configure the name of your frontend language cookie name
+    feLanguageCookieName: ''

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,3 +2,5 @@ Wegmeister:
   LanguageRedirect:
     # Add mappings for language codes if you use some different codes than the default ones.
     languageCodeOverrides: {}
+    # configure the name of your frontend language cookie name
+    feLanguageCookieName: _fe_language

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,6 @@ Wegmeister:
     languageCodeOverrides:
       # For example, if you use "cz" instead of "cs" for Czech, you can add this mapping:
       cs: cz
-      # configure the name of your frontend language cookie name
+      # configure the name of your frontend language cookie
       feLanguageCookieName: _fe_language
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,8 @@ Then run `composer update` in your project root.
 ## Configuration
 
 Sometimes language codes are not configured the same as in Neos. Therefore you can configure a mapping in your `Settings.yaml`:
+Also you can configure a feLanguageCookieName to get a cookie value from your frontend in case you want your users last
+opened language to reopen the next time he visits your website.
 
 ```yaml
 Wegmeister:
@@ -23,4 +25,6 @@ Wegmeister:
     languageCodeOverrides:
       # For example, if you use "cz" instead of "cs" for Czech, you can add this mapping:
       cs: cz
+      # configure the name of your frontend language cookie name
+      feLanguageCookieName: _fe_language
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,9 @@ Then run `composer update` in your project root.
 Sometimes language codes are not configured the same as in Neos. Therefore you can configure a mapping in your `Settings.yaml`:
 Also you can configure a feLanguageCookieName to get a cookie value from your frontend in case you want your users last
 opened language to reopen the next time he visits your website.
+The `feLanguageCookieName` allows you to read a cookie that contains a default language.
+Perhaps you can use this to always load the last language the user opened
+by setting the cookie when he changes the language via the language menu on your website.
 
 ```yaml
 Wegmeister:
@@ -25,6 +28,6 @@ Wegmeister:
     languageCodeOverrides:
       # For example, if you use "cz" instead of "cs" for Czech, you can add this mapping:
       cs: cz
-      # configure the name of your frontend language cookie
-      feLanguageCookieName: _fe_language
+    # configure the name of your frontend language cookie
+    feLanguageCookieName: _fe_language
 ```


### PR DESCRIPTION
In our projects we set a frontend language cookie whenever the user changes the language via the language menu.
Like that the user will always get on the language he visited last and doesn't have to switch the language everytime he revisits your website.

We think that this functionality may also be useful for others hence why we create this merge request.

Best Regards
Yannis